### PR TITLE
Remove name field

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -3,7 +3,6 @@
     "assets": [
         {
             "identifier": "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c",
-            "name": "$IRON",
             "symbol": "IRON",
             "decimals": 8,
             "logoURI": "https://ironfish.network/favicon.ico",

--- a/testnet.json
+++ b/testnet.json
@@ -3,7 +3,6 @@
     "assets": [
         {
             "identifier": "51f33a2f14f92735e562dc658a5639279ddca3d5079a6d1242b2a588a9cbf44c",
-            "name": "$IRON",
             "symbol": "IRON",
             "decimals": 8,
             "logoURI": "https://ironfish.network/favicon.ico",


### PR DESCRIPTION
The name field exists in the on-chain metadata so its not needed here 
